### PR TITLE
raid: raid add base bdev

### DIFF
--- a/module/bdev/raid/bdev_raid.c
+++ b/module/bdev/raid/bdev_raid.c
@@ -1604,6 +1604,26 @@ raid_bdev_add_base_device(struct raid_bdev *raid_bdev, const char *name, uint8_t
 	return 0;
 }
 
+static int
+fill_matrix(void) {
+	SPDK_ERRLOG("Fill matrix's stub\n");
+	return 0;
+};
+
+int
+raid_add_bdev(struct raid_bdev *raid_bdev, char *base_bdev, uint8_t slot) {
+	int rc;
+
+	rc = raid_bdev_add_base_device(raid_bdev, base_bdev, slot);
+	if (rc)
+		return rc;
+
+	rc = fill_matrix();
+	if (rc)
+		SPDK_ERRLOG("Failed to copy data to adding base bdev\n");
+	return rc;
+};
+
 /*
  * brief:
  * raid_bdev_examine function is the examine function call by the below layers

--- a/module/bdev/raid/bdev_raid.h
+++ b/module/bdev/raid/bdev_raid.h
@@ -190,6 +190,7 @@ const char *raid_bdev_state_to_str(enum raid_bdev_state state);
 void raid_bdev_write_info_json(struct raid_bdev *raid_bdev, struct spdk_json_write_ctx *w);
 int raid_bdev_remove_base_bdev(struct spdk_bdev *base_bdev, raid_bdev_remove_base_bdev_cb cb_fn,
 			       void *cb_ctx);
+int raid_add_bdev(struct raid_bdev *raid_bdev, char *base_bdev, uint8_t slot);
 
 /*
  * RAID module descriptor
@@ -253,11 +254,6 @@ struct raid_bdev_module {
 	 * is satisfied.
 	 */
 	void (*resize)(struct raid_bdev *raid_bdev);
-
-	/*
-	 * Called when a base_bdev is adding to degraded raid.
-	 */
-	int (*add_base_bdev)(struct raid_bdev *raid_bdev, char *base_bdev, uint8_t slot);
 	
 	TAILQ_ENTRY(raid_bdev_module) link;
 };

--- a/module/bdev/raid/bdev_raid.h
+++ b/module/bdev/raid/bdev_raid.h
@@ -257,8 +257,8 @@ struct raid_bdev_module {
 	/*
 	 * Called when a base_bdev is adding to degraded raid.
 	 */
-	int (*add_base_bdev)(struct raid_bdev *raid_bdev, char *base_bdev, uint8_t slot)
-
+	int (*add_base_bdev)(struct raid_bdev *raid_bdev, char *base_bdev, uint8_t slot);
+	
 	TAILQ_ENTRY(raid_bdev_module) link;
 };
 

--- a/module/bdev/raid/bdev_raid.h
+++ b/module/bdev/raid/bdev_raid.h
@@ -254,6 +254,11 @@ struct raid_bdev_module {
 	 */
 	void (*resize)(struct raid_bdev *raid_bdev);
 
+	/*
+	 * Called when a base_bdev is adding to degraded raid.
+	 */
+	int (*add_base_bdev)(struct raid_bdev *raid_bdev, char *base_bdev, uint8_t slot)
+
 	TAILQ_ENTRY(raid_bdev_module) link;
 };
 

--- a/module/bdev/raid/bdev_raid_rpc.c
+++ b/module/bdev/raid/bdev_raid_rpc.c
@@ -516,6 +516,7 @@ rpc_bdev_raid_add_base_bdev(struct spdk_jsonrpc_request *request,
 		} else {
 			SPDK_DEBUGLOG(bdev_raid, "base bdev %s added to raid bdev %s\n", base_bdev_name, req.name);
 		}
+		break;
 	}
 
 	spdk_jsonrpc_send_bool_response(request, true);

--- a/module/bdev/raid/bdev_raid_rpc.c
+++ b/module/bdev/raid/bdev_raid_rpc.c
@@ -502,9 +502,9 @@ rpc_bdev_raid_add_base_bdev(struct spdk_jsonrpc_request *request,
 	}
 
 	for (uint8_t i = 0; i < raid_bdev->num_base_bdevs; i++) {
-		if (raid_bdev->base_bdev_info->name != NULL)
+		if (raid_bdev->base_bdev_info[i].name != NULL)
 			continue;
-		rc = raid_bdev->module->add_base_bdev(raid_bdev, req.base_bdev, i);
+		rc = raid_add_bdev(raid_bdev, req.base_bdev, i);
 		if (rc == -ENODEV) {
 			SPDK_DEBUGLOG(bdev_raid, "base bdev %s doesn't exist now\n", base_bdev_name);
 		} else if (rc != 0) {

--- a/module/bdev/raid/raid1.c
+++ b/module/bdev/raid/raid1.c
@@ -209,6 +209,38 @@ raid1_stop(struct raid_bdev *raid_bdev)
 	return true;
 }
 
+static int
+raid1_copy_data_to_base_bdev(struct raid_bdev *raid_bdev, char *base_bdev, uint8_t slot) {
+	//it's don't work and can't work
+
+	// for (i = 0; i < raid_bdev->num_base_bdevs; i++) {
+	// 	if (raid_bdev->base_bdev_info[i].name == NULL || i == slot)
+	// 		continue;
+	// 	else {
+	// 		// struct *src_bdev = raid_bdev->base_bdev_info[i].desc;
+	// 		// struct *dst_bdev = spdk_bdev_get_by_name(base_bdev);
+	// 		// struct *spdk_io_channel src_channel = spdk_bdev_get_io_channel(src_bdev);
+	// 		// struct *spdk_io_channel dst_channel = spdk_bdev_get_io_channel(dst_bdev);
+	// 		// return spdk_bdev_copy_blocks(dst_bdev, );
+	// 	}
+	// }
+	SPDK_ERRLOG("Start the stub for copy data to base bdev\n");
+}
+
+static int
+raid1_add_bdev(struct raid_bdev *raid_bdev, char *base_bdev, uint8_t slot) {
+	int rc;
+
+	rc = raid_bdev_add_base_device(raid_bdev, base_bdev_name, i);
+	if (rc)
+		return rc;
+
+	rc = raid1_copy_data_to_base_bdev(raid_bdev, base_bdev, slot);
+	if (rc)
+		SPDK_ERRLOG("Faild to copy data to adding base bdev\n");
+	return rc
+}
+
 static struct raid_bdev_module g_raid1_module = {
 	.level = RAID1,
 	.base_bdevs_min = 2,
@@ -217,6 +249,7 @@ static struct raid_bdev_module g_raid1_module = {
 	.start = raid1_start,
 	.stop = raid1_stop,
 	.submit_rw_request = raid1_submit_rw_request,
+	.add_base_bdev = raid1_add_bdev,
 };
 RAID_MODULE_REGISTER(&g_raid1_module)
 

--- a/module/bdev/raid/raid1.c
+++ b/module/bdev/raid/raid1.c
@@ -225,20 +225,21 @@ raid1_copy_data_to_base_bdev(struct raid_bdev *raid_bdev, char *base_bdev, uint8
 	// 	}
 	// }
 	SPDK_ERRLOG("Start the stub for copy data to base bdev\n");
+	return 0;
 }
 
 static int
 raid1_add_bdev(struct raid_bdev *raid_bdev, char *base_bdev, uint8_t slot) {
 	int rc;
 
-	rc = raid_bdev_add_base_device(raid_bdev, base_bdev_name, i);
+	rc = raid_bdev_add_base_device(raid_bdev, base_bdev, slot);
 	if (rc)
 		return rc;
 
 	rc = raid1_copy_data_to_base_bdev(raid_bdev, base_bdev, slot);
 	if (rc)
 		SPDK_ERRLOG("Faild to copy data to adding base bdev\n");
-	return rc
+	return rc;
 }
 
 static struct raid_bdev_module g_raid1_module = {

--- a/module/bdev/raid/raid1.c
+++ b/module/bdev/raid/raid1.c
@@ -209,39 +209,6 @@ raid1_stop(struct raid_bdev *raid_bdev)
 	return true;
 }
 
-static int
-raid1_copy_data_to_base_bdev(struct raid_bdev *raid_bdev, char *base_bdev, uint8_t slot) {
-	//it's don't work and can't work
-
-	// for (i = 0; i < raid_bdev->num_base_bdevs; i++) {
-	// 	if (raid_bdev->base_bdev_info[i].name == NULL || i == slot)
-	// 		continue;
-	// 	else {
-	// 		// struct *src_bdev = raid_bdev->base_bdev_info[i].desc;
-	// 		// struct *dst_bdev = spdk_bdev_get_by_name(base_bdev);
-	// 		// struct *spdk_io_channel src_channel = spdk_bdev_get_io_channel(src_bdev);
-	// 		// struct *spdk_io_channel dst_channel = spdk_bdev_get_io_channel(dst_bdev);
-	// 		// return spdk_bdev_copy_blocks(dst_bdev, );
-	// 	}
-	// }
-	SPDK_ERRLOG("Start the stub for copy data to base bdev\n");
-	return 0;
-}
-
-static int
-raid1_add_bdev(struct raid_bdev *raid_bdev, char *base_bdev, uint8_t slot) {
-	int rc;
-
-	rc = raid_bdev_add_base_device(raid_bdev, base_bdev, slot);
-	if (rc)
-		return rc;
-
-	rc = raid1_copy_data_to_base_bdev(raid_bdev, base_bdev, slot);
-	if (rc)
-		SPDK_ERRLOG("Faild to copy data to adding base bdev\n");
-	return rc;
-}
-
 static struct raid_bdev_module g_raid1_module = {
 	.level = RAID1,
 	.base_bdevs_min = 2,
@@ -250,7 +217,6 @@ static struct raid_bdev_module g_raid1_module = {
 	.start = raid1_start,
 	.stop = raid1_stop,
 	.submit_rw_request = raid1_submit_rw_request,
-	.add_base_bdev = raid1_add_bdev,
 };
 RAID_MODULE_REGISTER(&g_raid1_module)
 

--- a/python/spdk/rpc/bdev.py
+++ b/python/spdk/rpc/bdev.py
@@ -448,6 +448,20 @@ def bdev_raid_remove_base_bdev(client, name):
     params = {'name': name}
     return client.call('bdev_raid_remove_base_bdev', params)
 
+def bdev_raid_add_base_bdev(client, name, base_bdev):
+    """Add base bdev to existing raid bdev
+
+    Args:
+        name: raid name
+        base_bdev: base bdev name
+
+    Returns:
+        None
+    """
+    params = {'name': name,
+              'base_bdev': base_bdev}
+    return client.call('bdev_raid_add_base_bdev', params)
+
 
 def bdev_aio_create(client, filename, name, block_size=None, readonly=False):
     """Construct a Linux AIO block device.

--- a/scripts/rpc.py
+++ b/scripts/rpc.py
@@ -2138,6 +2138,15 @@ Format: 'user:u1 secret:s1 muser:mu1 msecret:ms1,user:u2 secret:s2 muser:mu2 mse
     p.add_argument('name', help='base bdev name')
     p.set_defaults(func=bdev_raid_remove_base_bdev)
 
+    def bdev_raid_add_base_bdev(args):
+            rpc.bdev.bdev_raid_add_base_bdev(args.client,
+                                                name=args.name,
+                                                nase_bdev=args.base_bdev)
+    p = subparsers.add_parser('bdev_raid_add_base_bdev', help='Add a basic bdev to an existing raid bdev')
+    p.add_argument('-n', '--name', help='raid bdev name', required=True)
+    p.add_argument('-b', '--base-bdev', help = 'base bdev name', required=True)
+    p.set_defaults(func=bdev_raid_add_base_bdev)
+
     # split
     def bdev_split_create(args):
         print_array(rpc.bdev.bdev_split_create(args.client,

--- a/scripts/rpc.py
+++ b/scripts/rpc.py
@@ -2141,7 +2141,7 @@ Format: 'user:u1 secret:s1 muser:mu1 msecret:ms1,user:u2 secret:s2 muser:mu2 mse
     def bdev_raid_add_base_bdev(args):
             rpc.bdev.bdev_raid_add_base_bdev(args.client,
                                                 name=args.name,
-                                                nase_bdev=args.base_bdev)
+                                                base_bdev=args.base_bdev)
     p = subparsers.add_parser('bdev_raid_add_base_bdev', help='Add a basic bdev to an existing raid bdev')
     p.add_argument('-n', '--name', help='raid bdev name', required=True)
     p.add_argument('-b', '--base-bdev', help = 'base bdev name', required=True)


### PR DESCRIPTION
Add functions to add base bdev to a degraded raid:

> to do this, partially modify the raid configuration functions to adapt them for adding bdev to a working raid

To use: run rpc.py with parameter `bdev_raid_add_base_bdev -n RAID_NAME -b BASE_BDEV_NAME`